### PR TITLE
Revert "Update to GoReleaser v2.10.0"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: 'stable'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5014328cd6593ee3d003b8857c57d519c77ead1a
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser


### PR DESCRIPTION
This reverts commit 12a3596295bf5e8ceed75ed5e7d7060bc3b408d3. GoReleaser and its action are separate, and the action does not have an update even though GoReleaser does.